### PR TITLE
Allows to ignore some project files by regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,11 @@
     "configuration": {
       "title": "IAR Build",
       "properties": {
+        "iar-build.projectsToExclude": {
+          "type": "string",
+          "markdownDescription": "All projects that match this regex will be ignored. Empty regex means no ignore.",
+          "default": ""
+        },
         "iar-build.iarInstallDirectories": {
           "type": "array",
           "items": {

--- a/src/extension/ewpfilewatcher.ts
+++ b/src/extension/ewpfilewatcher.ts
@@ -85,19 +85,19 @@ class EwpFilesWatcher {
     constructor() {
         this.ewpFilesWatcher = vscode.workspace.createFileSystemWatcher("**/*.ewp");
         this.ewpFilesWatcher.onDidCreate(uri => {
-            if (Project.isBackupFile(uri.fsPath)) {
+            if (Project.isIgnoredFile(uri.fsPath)) {
                 return;
             }
             this.createdCallbacks.forEach(cb => cb(uri.fsPath));
         });
         this.ewpFilesWatcher.onDidChange(uri => {
-            if (Project.isBackupFile(uri.fsPath)) {
+            if (Project.isIgnoredFile(uri.fsPath)) {
                 return;
             }
             this.modifiedCallbacks.forEach(cb => cb(uri.fsPath));
         });
         this.ewpFilesWatcher.onDidDelete(uri => {
-            if (Project.isBackupFile(uri.fsPath)) {
+            if (Project.isIgnoredFile(uri.fsPath)) {
                 return;
             }
             this.deletedCallbacks.forEach(cb => cb(uri.fsPath));

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -106,7 +106,7 @@ export async function deactivate() {
 
 async function findProjectsInWorkspace() {
     if (vscode.workspace.workspaceFolders !== undefined) {
-        const projectFiles = (await vscode.workspace.findFiles("**/*.ewp")).filter(uri => !Project.isBackupFile(uri.fsPath));
+        const projectFiles = (await vscode.workspace.findFiles("**/*.ewp")).filter(uri => !Project.isIgnoredFile(uri.fsPath));
         logger.debug(`Found ${projectFiles.length} project(s) in the workspace`);
         const projects: Project[] = [];
         projectFiles.forEach(uri => {

--- a/src/iar/project/project.ts
+++ b/src/iar/project/project.ts
@@ -4,6 +4,7 @@
 
 
 
+import * as vscode from "vscode";
 import * as Path from "path";
 import { Config } from "./config";
 import { Node } from "iar-vsc-common/thrift/bindings/projectmanager_types";
@@ -56,10 +57,17 @@ export interface ExtendedProject extends Project {
 
 export namespace Project {
     /**
-     * Checks whether this is an automatic backup file. These should generally be ignored.
+     * Checks whether this file should be ignored.
      */
-    export function isBackupFile(projectFile: string): boolean {
-        return /^Backup\s+(\(\d+\)\s+)?of.*\.ewp$/.test(Path.basename(projectFile));
+    export function isIgnoredFile(projectFile: string): boolean {
+        // Checks whether this is an automatic backup file. These should generally be ignored.
+        const isBackupFile = /^Backup\s+(\(\d+\)\s+)?of.*\.ewp$/.test(Path.basename(projectFile));
+
+        // All projects that match this regex should be ignored
+        const projectsToExclude: string = vscode.workspace.getConfiguration("iar-build").get<string>("projectsToExclude")!;
+        const isIgnoredFile = projectsToExclude != '' && RegExp(projectsToExclude).test(projectFile);
+
+        return isBackupFile || isIgnoredFile;
     }
 
     export function equal(p1: Project, p2: Project) {


### PR DESCRIPTION
Our project folders contains multiple *.ewp files (most of them are
examples) and as a result I use only two ewp files. So I would like to
have option how hide others. This PR is example how to do it.